### PR TITLE
Changed cruise control min/max values to tolerable ESC values.

### DIFF
--- a/examples/RoboMagellan6x6/RoboMagellan6x6.ino
+++ b/examples/RoboMagellan6x6/RoboMagellan6x6.ino
@@ -1963,9 +1963,12 @@ void updateSteerSkew(float s)
 void newPIDparam(float x)
 {
 	// indexes for cruise control PID settings defined below
+	// Note: low and upper of [-90,90] exceed range of some ESCs
+	//       reducing to [-60,60] changed output range to 
+	//		 [900,2100] PWM 
 	cruisePID = PIDparameters(settings.get(11),
                               settings.get(12),
-                              settings.get(13), -90, 90 );
+                              settings.get(13), -60, 60 );
 }
 
 void stateStop()


### PR DESCRIPTION
Current ESCs can only tolerate values ~[800,2200] PWM.  This
update changed the cruise control values to always be within
[900,2100] PWM to ensure consistent functionality.