### PR TITLE
Updated library version number to support Arduino Lib Manager scrape.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MINDS-i-Drone
-version=1.5.0
+version=1.6.1
 author=MINDS-i corp.
 maintainer=MINDS-i <code@mymindsi.com>
 sentence=Code to assist with running MINDS-i Drones


### PR DESCRIPTION
Arduino Library manager was not displaying the 1.6.0 release as the newest library.  This was because the version number was not updated in the library properties and thus automatic scraping did not recognize the new release.